### PR TITLE
Fix qt5 port

### DIFF
--- a/README
+++ b/README
@@ -30,9 +30,9 @@ $ make deb
 
 Required packages:
 
-- To run the program: python-bluez python-qt4 python-numpy python-xlib
+- To run the program: python-bluez python-qt5 python-numpy python-xlib
   python python-support
-- To run make: libqt4-dev qt4-dev-tools python-qt4-dev
+- To run make: libqt5-dev qt5-dev-tools python-qt5-dev
 - To build the deb package: build-essential fakeroot dpkg-dev debhelper
 
 

--- a/stuff/configuration.py
+++ b/stuff/configuration.py
@@ -146,47 +146,34 @@ class ConfigDialog(QtWidgets.QDialog):
 		
 		self.wii = wii
 		
-		self.connect(self.ui.check_fullscreen,
-			QtCore.SIGNAL("stateChanged(int)"), self.checkStateChanged)
-		self.connect(self.ui.check_autoconnect,
-			QtCore.SIGNAL("stateChanged(int)"), self.checkStateChanged)
-		self.connect(self.ui.check_autocalibration,
-			QtCore.SIGNAL("stateChanged(int)"), self.checkStateChanged)
-		self.connect(self.ui.check_automatrix,
-			QtCore.SIGNAL("stateChanged(int)"), self.checkStateChanged)
-		self.connect(self.ui.check_nowait,
-			QtCore.SIGNAL("stateChanged(int)"), self.checkStateChanged)
+		self.ui.check_fullscreen.stateChanged.connect(self.checkStateChanged)
+		self.ui.check_autoconnect.stateChanged.connect(self.checkStateChanged)
+		self.ui.check_autocalibration.stateChanged.connect(self.checkStateChanged)
+		self.ui.check_automatrix.stateChanged.connect(self.checkStateChanged)
+		self.ui.check_nowait.stateChanged.connect(self.checkStateChanged)
 		
-		self.connect(self.ui.button_addDev,
-			QtCore.SIGNAL("clicked()"), self.addDevice)
-		self.connect(self.ui.button_remDev,
-			QtCore.SIGNAL("clicked()"), self.removeDevice)
+		self.ui.button_addDev.clicked.connect(self.addDevice)
+		self.ui.button_remDev.clicked.connect(self.removeDevice)
 		
 		pixmap = QtGui.QPixmap("screen.png")
-		self.areasScene = QtGui.QGraphicsScene()
+		self.areasScene = QtWidgets.QGraphicsScene()
 		self.areasScene.addPixmap(pixmap)
 		self.screenAreas.setScene(self.areasScene)
 		self.screenAreas.show()
 		
-		self.connect(self.ui.combo1,
-			QtCore.SIGNAL("currentIndexChanged(int)"), self.changeCombo)
-		self.connect(self.ui.combo2,
-			QtCore.SIGNAL("currentIndexChanged(int)"), self.changeCombo)
-		self.connect(self.ui.combo3,
-			QtCore.SIGNAL("currentIndexChanged(int)"), self.changeCombo)
-		self.connect(self.ui.combo4,
-			QtCore.SIGNAL("currentIndexChanged(int)"), self.changeCombo)
+		self.ui.combo1.currentIndexChanged.connect(self.changeCombo)
+		self.ui.combo2.currentIndexChanged.connect(self.changeCombo)
+		self.ui.combo3.currentIndexChanged.connect(self.changeCombo)
+		self.ui.combo4.currentIndexChanged.connect(self.changeCombo)
 		self.updateCombos()
 		
 		self.ui.slider_ir.setMinimum(1)
 		self.ui.slider_ir.setMaximum(6)
-		self.connect(self.ui.slider_ir,
-			QtCore.SIGNAL("valueChanged(int)"), self.sliderIrMoved)
+		self.ui.slider_ir.valueChanged.connect(self.sliderIrMoved)
 		
 		self.ui.slider_smoothing.setMinimum(1)
 		self.ui.slider_smoothing.setMaximum(10)
-		self.connect(self.ui.slider_smoothing,
-			QtCore.SIGNAL("valueChanged(int)"), self.sliderSmMoved)
+		self.ui.slider_smoothing.valueChanged.connect(self.sliderSmMoved)
 		
 		self.refreshWidgets()
 		self.checkButtons()
@@ -221,13 +208,12 @@ class ConfigDialog(QtWidgets.QDialog):
 	def setupMacTable(self):
 		self.ui.tableMac.setColumnCount(2)
 		self.ui.tableMac.setHorizontalHeaderLabels([self.tr('Address'), self.tr('Comment')])
-		self.ui.tableMac.setSelectionMode(QtGui.QTableWidget.SingleSelection)
-		self.ui.tableMac.setSelectionBehavior(QtGui.QTableWidget.SelectRows)
+		self.ui.tableMac.setSelectionMode(QtWidgets.QTableWidget.SingleSelection)
+		self.ui.tableMac.setSelectionBehavior(QtWidgets.QTableWidget.SelectRows)
 		self.refreshMacTable()
 		header = self.ui.tableMac.horizontalHeader()
 		header.setStretchLastSection(True)
-		self.connect(self.ui.tableMac,
-			QtCore.SIGNAL("cellClicked(int,int)"), self.macTableCellSelected)
+		self.ui.tableMac.cellClicked.connect(self.macTableCellSelected)
 	
 	
 	def macTableCellSelected(self,r,c):
@@ -241,9 +227,9 @@ class ConfigDialog(QtWidgets.QDialog):
 			self.ui.tableMac.removeRow(0)
 		
 		self.ui.tableMac.insertRow(0)
-		item = QtGui.QTableWidgetItem('*')
+		item = QtWidgets.QTableWidgetItem('*')
 		self.ui.tableMac.setItem(0,0,item)
-		item = QtGui.QTableWidgetItem(self.tr('All devices'))
+		item = QtWidgets.QTableWidgetItem(self.tr('All devices'))
 		self.ui.tableMac.setItem(0,1,item)
 		self.ui.tableMac.selectRow(0)
 		conf = Configuration()
@@ -251,9 +237,9 @@ class ConfigDialog(QtWidgets.QDialog):
 		for elem in lst:
 			rc = self.ui.tableMac.rowCount()
 			self.ui.tableMac.insertRow(rc)
-			item = QtGui.QTableWidgetItem(elem['address'])
+			item = QtWidgets.QTableWidgetItem(elem['address'])
 			self.ui.tableMac.setItem(rc,0,item)
-			item = QtGui.QTableWidgetItem(elem['comment'])
+			item = QtWidgets.QTableWidgetItem(elem['comment'])
 			self.ui.tableMac.setItem(rc,1,item)
 			selected = conf.getValueStr('selectedmac')
 			if selected == elem['address']:
@@ -270,7 +256,7 @@ class ConfigDialog(QtWidgets.QDialog):
 		for item in d:
 			if item['address'] == address: return
 		
-		comment, ok = QtGui.QInputDialog.getText(self,
+		comment, ok = QtWidgets.QInputDialog.getText(self,
 			self.tr("Comment"), self.tr('Wii device description'))
 		
 		if ok:

--- a/stuff/configuration.py
+++ b/stuff/configuration.py
@@ -49,7 +49,10 @@ class Configuration:
 
 		
 		def getValueStr(self,name):
-			v = self.settings.value(name).toString()
+			v = self.settings.value(name)
+			if v is None:
+				v = ''
+			v = str(v)
 			if v != '': return v
 			if v == '' and name in self.defaults.keys():
 				return self.defaults[name]

--- a/stuff/pywhiteboard.py
+++ b/stuff/pywhiteboard.py
@@ -21,8 +21,7 @@ class AboutDlg(QtWidgets.QDialog):
 	def __init__(self, parent=None):
 		super(AboutDlg, self).__init__(parent)
 		self.ui = uic.loadUi("about.ui",self)
-		self.connect(self.ui.butOK,
-			QtCore.SIGNAL("clicked()"), self.close)
+		self.ui.butOK.clicked.connect(self.close)
 
 
 
@@ -33,10 +32,8 @@ class PBarDlg(QtWidgets.QDialog):
 		self.ui = uic.loadUi("pbar.ui",self)
 		self.cancelled = False
 		self.choice = 0
-		self.connect(self.ui.butCancel,
-			QtCore.SIGNAL("clicked()"), self.cancelConnection)
-		self.connect(self.ui.butChoose,
-			QtCore.SIGNAL("clicked()"), self.makeChoice)
+		self.ui.butCancel.clicked.connect(self.cancelConnection)
+		self.ui.butChoose.clicked.connect(self.makeChoice)
 		self.ui.butChoose.hide()
 	
 	def reInit(self,mac='*'):
@@ -89,51 +86,32 @@ class MainWindow(QtWidgets.QMainWindow):
 		
 		conf = Configuration()
 
-		self.connect(self.ui.pushButtonConnect,
-			QtCore.SIGNAL("clicked()"), self.connectWii)
-		
-		self.connect(self.ui.pushButtonCalibrate,
-			QtCore.SIGNAL("clicked()"), self.calibrateWiiScreen)
-		
-		self.connect(self.ui.pushButtonActivate,
-			QtCore.SIGNAL("clicked()"), self.activateWii)
-		
-		self.connect(self.ui.pushButtonLoadCal,
-			QtCore.SIGNAL("clicked()"), self.calibrateWiiFromSettings)
-		
-		self.connect(self.ui.pushButtonSettings,
-			QtCore.SIGNAL("clicked()"), self.showHideSettings)
-		
-		self.connect(self.ui.comboProfiles,
-			QtCore.SIGNAL("currentIndexChanged(int)"), self.changeProfile)
-		
+		self.ui.pushButtonConnect.clicked.connect(self.connectWii)
+		self.ui.pushButtonCalibrate.clicked.connect(self.calibrateWiiScreen)
+		self.ui.pushButtonActivate.clicked.connect(self.activateWii)
+		self.ui.pushButtonLoadCal.clicked.connect(self.calibrateWiiFromSettings)
+		self.ui.pushButtonSettings.clicked.connect(self.showHideSettings)
+		self.ui.comboProfiles.currentIndexChanged.connect(self.changeProfile)
 		self.updateButtons()
-		
-		self.connect(self.ui.actionQuit,
-			QtCore.SIGNAL("activated()"), self.mustQuit)
-		self.connect(self.ui.actionHelp,
-			QtCore.SIGNAL("activated()"), self.showAboutDlg)
-		self.connect(self.ui.actionNew_Profile,
-			QtCore.SIGNAL("activated()"), self.addProfile)
-		self.connect(self.ui.actionDelete_Current_Profile,
-			QtCore.SIGNAL("activated()"), self.delCurrentProfile)
-		self.connect(self.ui.actionWipe_configuration,
-			QtCore.SIGNAL("activated()"), self.wipeConfiguration)
-		
-		
+
+		self.ui.actionQuit.triggered.connect(self.mustQuit)
+		self.ui.actionHelp.triggered.connect(self.showAboutDlg)
+		self.ui.actionNew_Profile.triggered.connect(self.addProfile)
+		self.ui.actionDelete_Current_Profile.triggered.connect(self.delCurrentProfile)
+		self.ui.actionWipe_configuration.triggered.connect(self.wipeConfiguration)
+
 		self.ui.moveOnlyCheck.setChecked( conf.getValueStr('moveonly') == 'Yes' )
-		self.connect(self.ui.moveOnlyCheck,
-			QtCore.SIGNAL("stateChanged(int)"), self.checkMoveOnly)
-		
+		self.ui.moveOnlyCheck.stateChanged.connect(self.checkMoveOnly)
+
 		if conf.getValueStr("autoconnect") == "Yes":
 			self.timer = qt.QTimer(self)
 			self.timer.setInterval(500)
-			self.connect(self.timer, QtCore.SIGNAL("timeout()"), self.autoConnect)
+			self.timer.timeout.connect(self.autoConnect)
 			self.timer.start()
 		
 		self.timer2 = qt.QTimer(self)
 		self.timer2.setInterval(4000)
-		self.connect(self.timer2, QtCore.SIGNAL("timeout()"), self.checkWii)
+		self.timer2.timeout.connect(self.checkWii)
 		self.timer2.start()
 		
 		self.confDialog = ConfigDialog(self, self.wii)
@@ -278,7 +256,7 @@ class MainWindow(QtWidgets.QMainWindow):
 		max_y = self.wiiScreen.geometry().height()
 		self.scene = qt.QGraphicsScene()
 		self.scene.setSceneRect(0,0,max_x,max_y)
-		quad = QtWidgets.QPolygonF()
+		quad = QtGui.QPolygonF()
 		for p in self.wii.calibrationPoints:
 			x = max_x * p[0]/Wiimote.MAX_X
 			y = max_y * (1-float(p[1])/Wiimote.MAX_Y)
@@ -625,10 +603,9 @@ class SysTrayIcon(object):
 	def __init__(self, fname, mainWindow):
 		self.mainWindow = mainWindow
 		self.stray = QtWidgets.QSystemTrayIcon()
-		self.stray.setIcon(QtWidgets.QIcon(fname))
+		self.stray.setIcon(QtGui.QIcon(fname))
 
-		QtCore.QObject.connect(self.stray,
-			QtCore.SIGNAL("activated(QSystemTrayIcon::ActivationReason)"), self.activate)
+		self.stray.activated.connect(self.activate)
 	
 	def activate(self, reason):
 		if reason == QtWidgets.QSystemTrayIcon.Trigger:

--- a/stuff/pywhiteboard.py
+++ b/stuff/pywhiteboard.py
@@ -9,7 +9,7 @@ from calibration import doCalibration, CalibrationAbort
 from configuration import Configuration, ConfigDialog
 
 
-import sys, time, locale
+import sys, time, locale, traceback
 import hashlib
 
 from PyQt5 import QtCore, QtGui, QtWidgets, uic
@@ -489,6 +489,8 @@ class MainWindow(QtWidgets.QMainWindow):
 			pass
 		
 		except:
+			print("Error during Calibration")
+			traceback.print_exc(file=sys.stdout)
 			self.updateButtons()
 			msgbox = QtWidgets.QMessageBox( self )
 			msgbox.setText( self.tr("Error during Calibration") )


### PR DESCRIPTION
I had problems with the qt5 port of the software. I basically had three main problems:
- A lot of objects have been in the QtWidgets library instead of QtGui or the other way round.
- The old style connect is no longer supported in QT5
- I had a number of `Timers cannot be started from another thread` messages caused by the `makeWiiCallback`